### PR TITLE
suppress warning from torchvision update since 17.0 on 'antialias' and requirement update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+venv/
+superbench_v1.tar

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-Python~=3.9.15
+# Python~=3.9.15
+# decimal~=1.70
 torch>=1.8.1+cu101
 numpy~=1.23.5
 matplotlib~=3.6.2
 tqdm~=4.64.1
 timm~=0.6.12
 cmocean~=2.0
-decimal~=1.70
 h5py~=3.7.0
-torchvision~=0.9.1+cu101
+torchvision~=0.9.1
 pandas~=1.4.4

--- a/src/data_loader_crop.py
+++ b/src/data_loader_crop.py
@@ -73,9 +73,9 @@ class GetFluidDataset(Dataset):
         self.crop_transform = transforms.RandomCrop(crop_size)
         self.method = method
         if (train == True) and (method == "bicubic"):
-            self.bicubicDown_transform = transforms.Resize((int(self.crop_size/upscale_factor),int(self.crop_size/upscale_factor)),Image.BICUBIC)  # subsampling the image (half size)
+            self.bicubicDown_transform = transforms.Resize((int(self.crop_size/upscale_factor),int(self.crop_size/upscale_factor)),Image.BICUBIC, antialias=True)  # subsampling the image (half size)
         elif (train == False) and (method == "bicubic"):
-            self.bicubicDown_transform = transforms.Resize((int(self.img_shape_x/upscale_factor),int(self.img_shape_y/upscale_factor)),Image.BICUBIC)  # subsampling the image (half size)
+            self.bicubicDown_transform = transforms.Resize((int(self.img_shape_x/upscale_factor),int(self.img_shape_y/upscale_factor)),Image.BICUBIC, antialias=True)  # subsampling the image (half size)
 
 
     def _get_files_stats(self):
@@ -160,9 +160,9 @@ class GetClimateDataset(Dataset):
         self.crop_transform = transforms.RandomCrop(crop_size)
         # we will always crop the image into square patches
         if (self.train == True) and (method == "bicubic"):
-            self.bicubicDown_transform = transforms.Resize((int(self.crop_size/upscale_factor),int(self.crop_size/upscale_factor)),Image.BICUBIC)  # subsampling the image (half size)
+            self.bicubicDown_transform = transforms.Resize((int(self.crop_size/upscale_factor),int(self.crop_size/upscale_factor)),Image.BICUBIC, antialias=True)  # subsampling the image (half size)
         elif (self.train == False) and (method == "bicubic"):
-            self.bicubicDown_transform = transforms.Resize((int((self.img_shape_x-1)/upscale_factor),int(self.img_shape_y/upscale_factor)),Image.BICUBIC)  # subsampling the image (half size)
+            self.bicubicDown_transform = transforms.Resize((int((self.img_shape_x-1)/upscale_factor),int(self.img_shape_y/upscale_factor)),Image.BICUBIC, antialias=True)  # subsampling the image (half size)
 
     def _get_files_stats(self):
         self.files_paths = glob.glob(self.location + "/*.h5")


### PR DESCRIPTION
Without specifying the antialias parameter, it defaults to None. This means antialiasing is applied when using PIL but not applied when tensors are resized directly.

For the requirement.txt, python version included would cause installation problem so I comment it out. 